### PR TITLE
Line 86: 'with open(output_file_name, "wb")' to 'with open(output_file_name, "w")'

### DIFF
--- a/gpx_csv_converter/__init__.py
+++ b/gpx_csv_converter/__init__.py
@@ -83,7 +83,7 @@ class Converter:
             this_row = [timestamp, lat, lng, elevation, heart_rate]
             row_list.append(this_row)
 
-        with open(output_file_name, "wb") as output_file:
+        with open(output_file_name, "w") as output_file:
             writer = csv.writer(output_file)
             writer.writerow(columns)
             writer.writerows(row_list)


### PR DESCRIPTION
### Issue:
Getting the following error when trying to use 'Converter(input_file=input_file, output_file=output_file)'. Changing line 86: 'with open(output_file_name, "wb")' to 'with open(output_file_name, "w")' seems to fix it. 

### Error:
File "/Users/sh/opt/anaconda3/envs/folder/lib/python3.9/site-packages/gpx_csv_converter/__init__.py", line 39, in __init__
    self.convert(gpx_string, output_file_name)
  File "/Users/sh/opt/anaconda3/envs/VfolderI/lib/python3.9/site-packages/gpx_csv_converter/__init__.py", line 88, in convert
    writer.writerow(columns)
TypeError: a bytes-like object is required, not 'str'

### Version:
Python 3.9.1

Name                    Version                   Build  Channel
ca-certificates           2021.1.19            hecd8cb5_0  
certifi                   2020.12.5        py39hecd8cb5_0  
gpx-csv-converter         0.2.3                    pypi_0    pypi
libcxx                    10.0.0                        1  
libedit                   3.1.20191231         h1de35cc_1  
libffi                    3.3                  hb1e8313_2  
ncurses                   6.2                  h0a44026_1  
openssl                   1.1.1i               h9ed2024_0  
pip                       20.3.3           py39hecd8cb5_0  
python                    3.9.1                h88f2d9e_2  
readline                  8.1                  h9ed2024_0  
setuptools                52.0.0           py39hecd8cb5_0  
sqlite                    3.33.0               hffcf06c_0  
tk                        8.6.10               hb0a8c7a_0  
tzdata                    2020f                h52ac0ba_0  
wheel                     0.36.2             pyhd3eb1b0_0  
xz                        5.2.5                h1de35cc_0  
zlib                      1.2.11               h1de35cc_3  

