### PR TITLE
feat: add cycling power metrics

### DIFF
--- a/gpx_csv_converter/__init__.py
+++ b/gpx_csv_converter/__init__.py
@@ -50,7 +50,7 @@ class Converter:
         trkpt = mydoc.getElementsByTagName("trkpt")
         row_list = []
 
-        columns = ["timestamp", "latitude", "longitude", "elevation", "heart_rate"]
+        columns = ["timestamp", "latitude", "longitude", "elevation", "heart_rate", "power"]
 
         # define type of heart rate field
         # garmin and other providers may have different elements for the hr field
@@ -59,6 +59,12 @@ class Converter:
         for potential_field in potential_fields_hr:
             if len(mydoc.getElementsByTagName(potential_field)) > 0:
                 heart_rate_field = potential_field
+                
+        potential_fields_pwr = ["pwr:PowerInWatts"]
+        power_field = potential_fields_pwr[0]  # default
+        for potential_field_1 in potential_fields_pwr:
+            if len(mydoc.getElementsByTagName(potential_field_1)) > 0:
+                power_field = potential_field_1
 
         # parse trackpoint elements. Search for child elements in each trackpoint so they stay in sync.
         for elem in trkpt:
@@ -80,10 +86,15 @@ class Converter:
             for selem in eheart_rate:
                 heart_rate = selem.firstChild.data
 
-            this_row = [timestamp, lat, lng, elevation, heart_rate]
+            epower = elem.getElementsByTagName(power_field)
+            power = None
+            for selem in epower:
+                power = selem.firstChild.data
+
+            this_row = [timestamp, lat, lng, elevation, heart_rate, power]
             row_list.append(this_row)
 
-        with open(output_file_name, "wb") as output_file:
+        with open(output_file_name, "w") as output_file:
             writer = csv.writer(output_file)
             writer.writerow(columns)
             writer.writerows(row_list)


### PR DESCRIPTION
## Summary

This PR adds support for cycling power metrics, as exported from https://github.com/OpenTracksApp/OpenTracks. In their schema, cycling power from BLE cycling power meters gets parsed as `pwr:PowerInWatts` tag.

## Test plan
1. Get a GPX dataset that contains power metrics
2. Run the script on it
You should see a `power` column with readings that match up with their relative data points in GPX

## Further comments

1. I'm no dev, I don't even speak Python, but I know how to use search and do copypasta. This is by no means efficient code, please feel free to make it so
2. I used the same fix as in #10 to make the script work, so this PR contains #10. I'll rebase if you merge it so that #10 author gets the credit :)